### PR TITLE
Improve support for new PHP8.2 standalone types

### DIFF
--- a/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
@@ -45,8 +45,9 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
      * false    PHP 8.0 (union return type only)
      * null     PHP 8.0 (union return type only)
      * never    PHP 8.1 (return type only)
-     * false    PHP 8.2 (standalone return type only)
-     * null     PHP 8.2 (standalone return type only)
+     * true     PHP 8.2 (standalone type: https://wiki.php.net/rfc/true-type)
+     * false    PHP 8.2 (standalone type: https://wiki.php.net/rfc/null-false-standalone-types)
+     * null     PHP 8.2 (standalone type: https://wiki.php.net/rfc/null-false-standalone-types)
      *
      * @var array<string, true>
      */
@@ -85,6 +86,10 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
 
         if (\PHP_VERSION_ID >= 80100) {
             $this->hints = array_merge($this->hints, ['never' => true]);
+        }
+
+        if (\PHP_VERSION_ID >= 80200) {
+            $this->hints = array_merge($this->hints, ['true' => true]);
         }
 
         $this->functionsAnalyzer = new FunctionsAnalyzer();

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -211,7 +211,7 @@ function Foo(INTEGER $a) {}
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): \Generator
+    public function provideFix82Cases(): iterable
     {
         yield 'standalone type `true`' => [
             '<?php class T { public function Foo(true $A): true {return $A;}}',

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -213,14 +213,19 @@ function Foo(INTEGER $a) {}
 
     public function provideFix82Cases(): \Generator
     {
-        yield 'return type `false`' => [
-            '<?php class T { public function Foo(object $A): false {return false;}}',
-            '<?php class T { public function Foo(object $A): FALSE {return false;}}',
+        yield 'standalone type `true`' => [
+            '<?php class T { public function Foo(true $A): true {return $A;}}',
+            '<?php class T { public function Foo(True $A): TRUE {return $A;}}',
         ];
 
-        yield 'return type `null`' => [
-            '<?php class T { public function Foo(object $A): null {return null;}}',
-            '<?php class T { public function Foo(object $A): NULL {return null;}}',
+        yield 'standalone type `false`' => [
+            '<?php class T { public function Foo(false $A): false {return $A;}}',
+            '<?php class T { public function Foo(False $A): FALSE {return $A;}}',
+        ];
+
+        yield 'standalone type `null`' => [
+            '<?php class T { public function Foo(null $A): null {return $A;}}',
+            '<?php class T { public function Foo(Null $A): NULL {return $A;}}',
         ];
     }
 }


### PR DESCRIPTION
Appendix to FriendsOfPHP/PHP-CS-Fixer#6427

- Add support for `true` type
- Use types also in functions' params